### PR TITLE
netCDF output: removed manual fill_value

### DIFF
--- a/globagrim/output.py
+++ b/globagrim/output.py
@@ -19,34 +19,34 @@ def init_output():
     lat = out.createDimension("lat", global_const.NK)
 
     # create variables
-    longitudes = out.createVariable("lon", np.float, "lon", fill_value=np.nan)
-    latitudes = out.createVariable("lat", np.float, "lat", fill_value=np.nan)
-    time = out.createVariable("time", np.float, "time", fill_value=np.nan)
+    longitudes = out.createVariable("lon", np.float, "lon")
+    latitudes = out.createVariable("lat", np.float, "lat")
+    time = out.createVariable("time", np.float, "time")
 
-    SE = out.createVariable("SE", np.float, ("lat", "lon"), fill_value=np.nan)
+    SE = out.createVariable("SE", np.float, ("lat", "lon"))
 
     PSG = out.createVariable(
-        "PSG", np.float, ("time", "lat", "lon"), fill_value=np.nan
+        "PSG", np.float, ("time", "lat", "lon")
     )  # NetCDF has (level, time, lat, lon) as standard
 
     T = out.createVariable(
-        "T", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "T", np.float, ("time", "level", "lat", "lon")
     )
 
     U = out.createVariable(
-        "U", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "U", np.float, ("time", "level", "lat", "lon")
     )
 
     V = out.createVariable(
-        "V", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "V", np.float, ("time", "level", "lat", "lon")
     )
 
     #    W = out.createVariable(
-    #        "W", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "W", np.float, ("time", "level", "lat", "lon")
     #    )
 
     #    GP = out.createVariable(
-    #        "GP", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "GP", np.float, ("time", "level", "lat", "lon")
     #    )
 
     # assign units


### PR DESCRIPTION
If we do not set the fill_value manually, then the defailt fill values
are used for the _FillValue attribute. `np.nan` is not a good choice
for a manually defined fill value. Commonly, very high or very low
numbers are choosen.