### PR TITLE
updated netCDF data types in output

### DIFF
--- a/globagrim/output.py
+++ b/globagrim/output.py
@@ -19,34 +19,34 @@ def init_output():
     lat = out.createDimension("lat", global_const.NK)
 
     # create variables
-    longitudes = out.createVariable("lon", np.float, "lon", fill_value=np.nan)
-    latitudes = out.createVariable("lat", np.float, "lat", fill_value=np.nan)
-    time = out.createVariable("time", np.float, "time", fill_value=np.nan)
+    longitudes = out.createVariable("lon", 'd', "lon", fill_value=np.nan)
+    latitudes = out.createVariable("lat", 'd', "lat", fill_value=np.nan)
+    time = out.createVariable("time", 'd', "time", fill_value=np.nan)
 
-    SE = out.createVariable("SE", np.float, ("lat", "lon"), fill_value=np.nan)
+    SE = out.createVariable("SE", 'f', ("lat", "lon"), fill_value=np.nan)
 
     PSG = out.createVariable(
-        "PSG", np.float, ("time", "lat", "lon"), fill_value=np.nan
+        "PSG", 'f', ("time", "lat", "lon"), fill_value=np.nan
     )  # NetCDF has (level, time, lat, lon) as standard
 
     T = out.createVariable(
-        "T", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "T", 'f', ("time", "level", "lat", "lon"), fill_value=np.nan
     )
 
     U = out.createVariable(
-        "U", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "U", 'f', ("time", "level", "lat", "lon"), fill_value=np.nan
     )
 
     V = out.createVariable(
-        "V", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "V", 'f', ("time", "level", "lat", "lon"), fill_value=np.nan
     )
 
     #    W = out.createVariable(
-    #        "W", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "W", 'f', ("time", "level", "lat", "lon"), fill_value=np.nan
     #    )
 
     #    GP = out.createVariable(
-    #        "GP", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "GP", 'f', ("time", "level", "lat", "lon"), fill_value=np.nan
     #    )
 
     # assign units


### PR DESCRIPTION
commonly

* coordinates variables are of type `double` (higher precision; higher
   numbers => `time` is seconds since => float often to small)
* data variables are of type `float`

possible input types for the netCDF python4 API are given here:

https://unidata.github.io/netcdf4-python/#Dataset.createVariable